### PR TITLE
Feat/35: Moved button icons beside button text

### DIFF
--- a/mobile/components/GreetingPage.js
+++ b/mobile/components/GreetingPage.js
@@ -81,13 +81,13 @@ export default class GreetingPage extends Component {
 
           <View style={styles.press_button}>
 
-            <View>
+            <View padding={15}>
             <Text style={styles.current_location_title}>
               Use Current Location
             </Text>
             </View>
 
-            <View marginTop = {20}>
+            <View marginTop = {5}>
               <Ionicons name="md-locate" size={40} color="white"/>
             </View>
 
@@ -98,13 +98,13 @@ export default class GreetingPage extends Component {
         <TouchableHighlight disabled style={styles.second_button_container}>
           <View style={styles.press_button}>
 
-            <View>
+            <View padding={15}>
              <Text style={styles.current_location_title}>
               Drop Pin
              </Text>
             </View>
 
-            <View marginTop = {20}>
+            <View>
               <Ionicons name="md-pin" size={40} color="white"/>
             </View>
 
@@ -140,7 +140,6 @@ const styles = StyleSheet.create( {
   },
   current_location_title: {
     color: '#FFF',
-    marginTop: 15,
     textAlign: 'center',
     opacity: 0.9,
     fontSize: 20
@@ -155,12 +154,16 @@ const styles = StyleSheet.create( {
     alignItems: 'stretch'
   },
   press_button: {
-    flexDirection: 'column',
-    justifyContent: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    // padding:5,
     alignItems: 'center'
   },
   second_button_container: {
     flex: 1,
-    backgroundColor: '#535c68'
+    backgroundColor: '#535c68',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'stretch'
   }
 })


### PR DESCRIPTION
Moved the icons on the greeting page buttons to beside the text. The icons are no longer being cut off. 